### PR TITLE
log details if the src is missing

### DIFF
--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -13,6 +13,9 @@ module.exports = function(grunt) {
     var options = this.options();
 
     var src = this.data.relativeSrc;
+    if (!fs.existsSync(src)) {
+     grunt.log.error(src + ' does not exist.');
+    }
     var dest = this.data.dest;
     try{
       grunt.log.ok('src', src);


### PR DESCRIPTION
Given that most users expect that the source file will already exist, I thought this logging would be helpful in case they accidentally specify the wrong path(as I had done prior to writing these lines).
